### PR TITLE
optional settings override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ db.sqlite3
 __pycache__
 log
 /.vagrant*
+/datavis/settings/override.py

--- a/datavis/settings/default.py
+++ b/datavis/settings/default.py
@@ -146,11 +146,6 @@ STATIC_URL = '/static/'
 #	Alias /static/ /var/django/ncharts/static/
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
-# People who should receive emails of ERRORs
-ADMINS = (
-    ('Gordon Maclean', 'maclean@ucar.edu'),
-    # ('Hien Nguyen', 'hnguyen@ucar.edu'),
-)
 EMAIL_HOST = "smtp.eol.ucar.edu"
 # Email address they appear to come from
 SERVER_EMAIL = getpass.getuser() + '@' + socket.getfqdn()

--- a/datavis/settings/default.py
+++ b/datavis/settings/default.py
@@ -17,6 +17,10 @@ import os, socket, getpass
 
 BASE_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
+def override_file_exists():
+  override_filepath = os.path.normpath(os.path.join(os.path.dirname(__file__),'override.py'))
+  return os.path.exists(override_filepath)
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
 
@@ -231,3 +235,5 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
 INTERNAL_IPS = ['128.117']
 
+if override_file_exists():
+  from .override import *

--- a/datavis/settings/override.datavis.eol.ucar.edu.py
+++ b/datavis/settings/override.datavis.eol.ucar.edu.py
@@ -1,0 +1,18 @@
+#
+# datavis override settings:
+#
+#   define local settings overrides here or in appropriate env-specific override file
+#
+# symbolically link this file or appropriate env-specific override file to override.py:
+#
+#   $ cd datavis/settings
+#   $ ln -s override.datavis.eol.ucar.edu.py override.py
+#
+
+#
+# People who should receive emails of ERRORs
+#
+ADMINS = (
+    ('Gordon Maclean', 'maclean@ucar.edu'),
+    ('Erik Johnson',   'ej@ucar.edu'),
+)

--- a/datavis/settings/production.py
+++ b/datavis/settings/production.py
@@ -63,3 +63,6 @@ if LOG_DIR != DEFAULT_LOG_DIR:
 
     if 'level' in value:
       value['level'] = LOG_LEVEL
+
+if override_file_exists():
+  from .override import *

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -12,9 +12,9 @@ To run in production mode, set `DJANGO_SETTINGS_MODULE` to `datavis.settings.pro
 export DJANGO_SETTINGS_MODULE=datavis.settings.production
 ```
 
-## Override
+## Override (optional)
 
-Settings can be overridden via an override file, `datavis/settings/override.py`. `override.py` is `.gitignore`d, so you can make environment-specific changes to settings without modifying files that are tracked in version control.
+Settings can be overridden via an optional override file, `datavis/settings/override.py`. `override.py` is `.gitignore`d, so you can make environment-specific changes to settings without modifying files that are tracked in version control.
 
 For example, production `ADMINS` for `datavis.eol.ucar.edu` are defined in `datavis/settings/override.datavis.eol.ucar.edu.py`. A symbolic link can made from this file to `override.py`
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,28 @@
+# ncharts Settings
+
+Django settings are defined in `datavis/settings`.
+
+Default values are defined in `default.py`, and then may be overridden by environment-specific settings files, such as `production.py` and `override.py`, which are described below.
+
+## Production
+
+To run in production mode, set `DJANGO_SETTINGS_MODULE` to `datavis.settings.production`. Production mode disables debug logging and configures allowed hosts. **When ncharts is exposed to the internet at large, it should be run in production mode.**
+
+```sh
+export DJANGO_SETTINGS_MODULE=datavis.settings.production
+```
+
+## Override
+
+Settings can be overridden via an override file, `datavis/settings/override.py`. `override.py` is `.gitignore`d, so you can make environment-specific changes to settings without modifying files that are tracked in version control.
+
+For example, production `ADMINS` for `datavis.eol.ucar.edu` are defined in `datavis/settings/override.datavis.eol.ucar.edu.py`. A symbolic link can made from this file to `override.py`
+
+```sh
+cd datavis/settings
+ln -s override.datavis.eol.ucar.edu.py override.py
+```
+
+Note that `override.py` is `import`ed at the **end** of `default.py` and `production.py`, so any settings that are **derived** from values defined within those respective files will need to be redefined in `override.py`.
+
+For example, `CACHES` is based on `VAR_RUN_DIR` in `production.py`. If `VAR_RUN_DIR` is overridden in `override.py`, then `CACHES` will need to be assigned again in `override.py` if `CACHES` is to be based on the overridden value of `VAR_RUN_DIR`.


### PR DESCRIPTION
- stop spamming @maclean w/ error notifications whenever running in production mode by...
- allowing settings to be defined in an optional settings override file that is not tracked in version control, to avoid conflicts between local settings and version-controlled settings
- details documented in [`docs/SETTINGS.md`](https://github.com/ncareol/ncharts/blob/feature-local-settings/docs/SETTINGS.md).