### PR TITLE
NRITW-2052: serve ncharts over HTTPS

### DIFF
--- a/datavis/settings/production.py
+++ b/datavis/settings/production.py
@@ -42,12 +42,10 @@ if SECRET_KEY is None:
 # client's browser. Setting ALLOWED_HOSTS to the various names for datavis will
 # result in packets being ignored if they contain other than the following:
 #
-ALLOWED_HOSTS = ['datavis', 'datavis.eol.ucar.edu', 'datavis-dev.eol.ucar.edu',
-                 'eol-datavis-dev-9.eol.ucar.edu', 'localhost', '128.117.82.210', '127.0.0.1']
+ALLOWED_HOSTS = ['datavis', 'datavis.eol.ucar.edu', 'datavis-dev.eol.ucar.edu', 'localhost', '128.117.82.210', '127.0.0.1']
 
 CSRF_TRUSTED_ORIGINS = [
     'https://datavis-dev.eol.ucar.edu',
-    'https://eol-datavis-dev-9.eol.ucar.edu',
     'https://datavis.eol.ucar.edu',      # for prod, once it has a cert
     'http://datavis-dev.eol.ucar.edu',   # existing; safe to keep during rollout
     'http://datavis.eol.ucar.edu',       # existing

--- a/datavis/settings/production.py
+++ b/datavis/settings/production.py
@@ -42,9 +42,29 @@ if SECRET_KEY is None:
 # client's browser. Setting ALLOWED_HOSTS to the various names for datavis will
 # result in packets being ignored if they contain other than the following:
 #
-ALLOWED_HOSTS = ['datavis', 'datavis.eol.ucar.edu', 'datavis-dev.eol.ucar.edu', 'localhost', '128.117.82.210', '127.0.0.1']
+ALLOWED_HOSTS = ['datavis', 'datavis.eol.ucar.edu', 'datavis-dev.eol.ucar.edu',
+                 'eol-datavis-dev-9.eol.ucar.edu', 'localhost', '128.117.82.210', '127.0.0.1']
 
-CSRF_TRUSTED_ORIGINS = ['http://datavis-dev.eol.ucar.edu', 'http://datavis.eol.ucar.edu']
+CSRF_TRUSTED_ORIGINS = [
+    'https://datavis-dev.eol.ucar.edu',
+    'https://eol-datavis-dev-9.eol.ucar.edu',
+    'https://datavis.eol.ucar.edu',      # for prod, once it has a cert
+    'http://datavis-dev.eol.ucar.edu',   # existing; safe to keep during rollout
+    'http://datavis.eol.ucar.edu',       # existing
+]
+
+# ncharts runs behind Apache, which terminates TLS and proxies to gunicorn over
+# plain HTTP. Trust Apache's X-Forwarded-Proto so request.is_secure() is correct.
+# Apache sets the header with `RequestHeader set` (overwriting any client value),
+# so clients cannot spoof it.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+# All HTTP is redirected to HTTPS at Apache, so cookies can be HTTPS-only.
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
+# Leave the HTTP->HTTPS redirect to Apache (the :80 vhost). Do NOT set
+# SECURE_SSL_REDIRECT here; with the proxy header it is redundant and risks a loop.
 
 # People who should receive emails of ERRORs
 ADMINS = (

--- a/etc/eol-datavis-dev-9/httpd/conf/vhosts/datavis-dev.conf
+++ b/etc/eol-datavis-dev-9/httpd/conf/vhosts/datavis-dev.conf
@@ -1,11 +1,54 @@
+# datavis-dev.eol.ucar.edu vhost -- HTTP + HTTPS (ncharts)
+#
+# NRITW-2052: serve ncharts over HTTPS. TLS terminates at Apache, which proxies to
+# gunicorn on 127.0.0.1:9000 (as the old :80 vhost did). The shared box cert lives
+# at /etc/letsencrypt/live/eol-datavis-dev-9.eol.ucar.edu/ (SANs datavis-dev +
+# eol-datavis-dev-9 + thp-dev; managed by certbot).
+#
+# :80 redirects everything to HTTPS and canonicalizes to datavis-dev.eol.ucar.edu
+# (so requests to the machine name eol-datavis-dev-9 land on the name the :443
+# vhost serves). The :443 vhost uses ServerName datavis-dev only; eol-datavis-dev-9
+# stays with mod_ssl's default :443 vhost, which loads first and presents the same
+# box cert. The two thp-dev path redirects are preserved.
+
 <VirtualHost *:80>
   ServerAdmin webmaster@eol.ucar.edu
   ServerName datavis-dev.eol.ucar.edu
+  ServerAlias eol-datavis-dev-9.eol.ucar.edu
   ErrorLog /var/log/httpd/datavis-dev.log
   LogLevel info
 
   RewriteEngine on
-  RewriteRule ^/admin(.*) http://127.0.0.1:9000%{REQUEST_URI} [P]
+
+  # Erik's app moved to its own host; keep redirecting these there (302, as before).
+  RewriteRule ^/dv2-api(/.*)?$          https://thp-dev.eol.ucar.edu/dv2-api$1          [R=302,L]
+  RewriteRule ^/time-height-plot(/.*)?$ https://thp-dev.eol.ucar.edu/time-height-plot$1 [R=302,L]
+
+  # Everything else: upgrade to HTTPS and canonicalize to datavis-dev, preserving
+  # path + query.
+  RewriteRule ^ https://datavis-dev.eol.ucar.edu%{REQUEST_URI} [R=301,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+  ServerAdmin webmaster@eol.ucar.edu
+  ServerName datavis-dev.eol.ucar.edu
+  # (No eol-datavis-dev-9 alias here: that name stays with mod_ssl's default :443
+  # vhost, and :80 canonicalizes to datavis-dev. Adding it would only produce an
+  # overlapping-ServerName warning.)
+  ErrorLog /var/log/httpd/datavis-dev-ssl.log
+  LogLevel info
+
+  SSLEngine on
+  SSLCertificateFile    /etc/letsencrypt/live/eol-datavis-dev-9.eol.ucar.edu/fullchain.pem
+  SSLCertificateKeyFile /etc/letsencrypt/live/eol-datavis-dev-9.eol.ucar.edu/privkey.pem
+
+  # TLS terminates here; we proxy to gunicorn over plain HTTP on 127.0.0.1:9000.
+  # Tell Django the original request was HTTPS. "set" overwrites any client-sent
+  # value, so a client cannot spoof it. Requires mod_headers.
+  RequestHeader set X-Forwarded-Proto "https"
+
+  RewriteEngine on
+  RewriteRule ^/admin(.*)   http://127.0.0.1:9000%{REQUEST_URI} [P]
   RewriteRule ^/ncharts(.*) http://127.0.0.1:9000%{REQUEST_URI} [P]
 
   <Directory /var/django/ncharts>
@@ -25,13 +68,7 @@
       Options -Indexes
   </Location>
 
-  #
-  # Redirect /dv2-api* to new domain
-  #
-  RedirectMatch ^/dv2-api(/.*)?$ https://thp-dev.eol.ucar.edu/dv2-api$1
-
-  #
-  # Redirect /time-height-plot* to new domain
-  #
+  # Keep the same redirects for Erik's moved app.
+  RedirectMatch ^/dv2-api(/.*)?$          https://thp-dev.eol.ucar.edu/dv2-api$1
   RedirectMatch ^/time-height-plot(/.*)?$ https://thp-dev.eol.ucar.edu/time-height-plot$1
 </VirtualHost>

--- a/etc/eol-datavis-dev-9/httpd/conf/vhosts/datavis-dev.conf
+++ b/etc/eol-datavis-dev-9/httpd/conf/vhosts/datavis-dev.conf
@@ -5,22 +5,24 @@
 # at /etc/letsencrypt/live/eol-datavis-dev-9.eol.ucar.edu/ (SANs datavis-dev +
 # eol-datavis-dev-9 + thp-dev; managed by certbot).
 #
-# :80 redirects everything to HTTPS and canonicalizes to datavis-dev.eol.ucar.edu
-# (so requests to the machine name eol-datavis-dev-9 land on the name the :443
-# vhost serves). The :443 vhost uses ServerName datavis-dev only; eol-datavis-dev-9
-# stays with mod_ssl's default :443 vhost, which loads first and presents the same
-# box cert. The two thp-dev path redirects are preserved.
+# :80 redirects everything to HTTPS, canonicalized to datavis-dev.eol.ucar.edu. It
+# is the default :80 vhost, so it also catches any other name pointed at this box
+# (including the machine's own physical hostname) and 301s it to the canonical
+# datavis-dev URL. We deliberately do not alias or advertise those ephemeral names.
+# The :443 vhost uses ServerName datavis-dev only; any other name over HTTPS falls to
+# mod_ssl's default :443 vhost (same box cert). The two THP path redirects are
+# preserved.
 
 <VirtualHost *:80>
   ServerAdmin webmaster@eol.ucar.edu
   ServerName datavis-dev.eol.ucar.edu
-  ServerAlias eol-datavis-dev-9.eol.ucar.edu
   ErrorLog /var/log/httpd/datavis-dev.log
   LogLevel info
 
   RewriteEngine on
 
-  # Erik's app moved to its own host; keep redirecting these there (302, as before).
+  # THP (Time Height Plot) is served by its own vhost (thp-dev.eol.ucar.edu); keep
+  # redirecting these paths there (302, as before).
   RewriteRule ^/dv2-api(/.*)?$          https://thp-dev.eol.ucar.edu/dv2-api$1          [R=302,L]
   RewriteRule ^/time-height-plot(/.*)?$ https://thp-dev.eol.ucar.edu/time-height-plot$1 [R=302,L]
 
@@ -68,7 +70,7 @@
       Options -Indexes
   </Location>
 
-  # Keep the same redirects for Erik's moved app.
+  # Keep the same redirects to THP (Time Height Plot) vhost at thp-dev.eol.ucar.edu.
   RedirectMatch ^/dv2-api(/.*)?$          https://thp-dev.eol.ucar.edu/dv2-api$1
   RedirectMatch ^/time-height-plot(/.*)?$ https://thp-dev.eol.ucar.edu/time-height-plot$1
 </VirtualHost>


### PR DESCRIPTION
## What
Enable HTTPS for ncharts on datavis-dev (NRITW-2052). Two files change:
- `etc/eol-datavis-dev-9/httpd/conf/vhosts/datavis-dev.conf`: adds a `*:443` vhost that mirrors the existing `:80` proxy to gunicorn on `127.0.0.1:9000` (same static aliases and thp-dev redirects), with TLS and a `RequestHeader set X-Forwarded-Proto "https"`. The `:80` vhost now redirects everything to HTTPS, canonicalized to `datavis-dev.eol.ucar.edu`.
- `datavis/settings/production.py`: adds `SECURE_PROXY_SSL_HEADER`, adds the `https://` origins to `CSRF_TRUSTED_ORIGINS`, and sets `SESSION_COOKIE_SECURE` and `CSRF_COOKIE_SECURE`.

## Cert
Reuses the shared box cert already on the host at `/etc/letsencrypt/live/eol-datavis-dev-9.eol.ucar.edu/` (SANs `datavis-dev.eol.ucar.edu`, `eol-datavis-dev-9.eol.ucar.edu`, `thp-dev.eol.ucar.edu`). No new cert is needed for dev.

## Scope
This changes only the ncharts vhost and `production.py`. It does not modify Erik's THP vhost or `ssl.conf`.

## Deploy notes (datavis-dev)
1. Merge to `develop` and update the datavis-dev checkout to `develop`.
2. Confirm the cert path exists: `sudo certbot certificates` should show the lineage covering `datavis-dev.eol.ucar.edu` at `/etc/letsencrypt/live/eol-datavis-dev-9.eol.ucar.edu/`.
3. Apache: copy just this vhost into `/etc/httpd/conf/vhosts/datavis-dev.conf` (not a blanket tree copy), then run `sudo httpd -t` (it must say `Syntax OK`) before `sudo systemctl reload httpd`.
4. Django: `sudo systemctl restart gunicorn`.

## Test
- `http://datavis-dev.eol.ucar.edu/ncharts/` and `http://eol-datavis-dev-9.eol.ucar.edu/ncharts/` both `301` to `https://datavis-dev.eol.ucar.edu/...`.
- `https://datavis-dev.eol.ucar.edu/ncharts/` serves ncharts with a valid cert (no warning).
- `https://eol-datavis-dev-9.eol.ucar.edu/ncharts/` returns `404` on the default vhost with a valid cert (expected).
- `https://thp-dev.eol.ucar.edu/` still works.
- Admin login or a form over HTTPS succeeds (CSRF passes).

## Follow-up (prod): no action taken here
To be clear: no cert has been issued for prod as part of this change, and nothing here touches the prod box. `datavis.eol.ucar.edu` is a separate server and needs its own cert. We are intentionally waiting until ncharts is live there; once it is, adding SSL is quick: issue a cert for that box and drop in an analogous `:443` vhost. `production.py` already carries the `datavis` https origin, so no further settings change is expected.